### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pefile
 ansi2html
 flask
 dncil
-dnfile>=0.14.1
+dnfile==0.14.1
 olefile
 oletools
 psutil


### PR DESCRIPTION
Since version 0.15.0 dnfile's UserStringHeap class doesn't contain get_us() func (replaced with get()), so you need to use version 0.14.1.

Source:
https://github.com/malwarefrank/dnfile/blob/v0.15.0/src/dnfile/stream.py#L259