### PR TITLE
Fix printoutcome command

### DIFF
--- a/avredhelper.py
+++ b/avredhelper.py
@@ -122,6 +122,8 @@ def main():
         printFileInfo(args.file)
     elif args.command == "augment":
         printFileDataInfo(args.file, args.offset, args.size)
+    elif args.command == "outcome":
+        printoutcome(args.file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The "outcome" subcommand did not do anything. Now it calls the "printoutcome" function.